### PR TITLE
SwiftPackageManager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,10 @@ fastlane/report.xml
 fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
+
+## Swift Package Manager
+Packages/
+Package.pins
+Package.resolved
+.swiftpm
+.build/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+	name: "AppSwizzle",
+	platforms: [
+		.iOS(.v12)
+		],
+	products: [
+		.library(
+			name: "AppSwizzle",
+			targets: ["AppSwizzle"]),
+	],
+	targets: [
+		.target(
+			name: "AppSwizzle",
+			path: "AppSwizzle/Classes"
+		),
+		.testTarget(
+			name: "AppSwizzleTests",
+			dependencies: ["AppSwizzle"],
+			path: "Example/Tests",
+			exclude: ["Info.plist"],
+			linkerSettings: [
+				.linkedFramework("UIKit")
+			])
+	]
+)
+


### PR DESCRIPTION
# SwiftPackageManager support

Tests are linked from `Example/Tests`, `Info.plist` was excluded since SPM tests in autogenerated project or through CLI does not need it.